### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ rock.py: Rock paper scissor game module
 snake1.py: Snake game module
 
 Combined.py: combined module for login.py and main.py. Main module through which the project runs
+
+
+
+
+[![Run on Repl.it](https://repl.it/badge/github/kybrdbnd/Python_Games)](https://repl.it/github/kybrdbnd/Python_Games)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Tvg_Gaming/PythonGames).